### PR TITLE
Update crate dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ name = "proxy"
 crate-type = ["cdylib"]
 
 [dependencies]
-libc = "0.2.70"
-once_cell = "1.4.0"
+libc = "0.2.146"
+once_cell = "1.18.0"
 
 [dev-dependencies]
-libloading = "0.6.2"
-rental = "0.5.5"
+libloading = "0.8.0"
+rental = "0.5.6"

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -24,7 +24,7 @@ rental! {
 
 impl NativeVM for ProxyModule {
     fn dll_entry(syscall: Syscall) -> Box<Self> {
-        let lib = lib::Library::new("target/debug/examples/hello").unwrap();
+        let lib = unsafe { lib::Library::new("target/debug/examples/hello").unwrap() };
         println!("qagame: {:?}", lib);
 
         let dll_entry: lib::Symbol<DllEntry> = unsafe { lib.get(DLLENTRY_EXPORT_NAME).unwrap() };


### PR DESCRIPTION
`rental` is unmaintained and could be replaced by `self_cell`.
`once_cell` is sort of available in Rust `std` now.